### PR TITLE
Fix skeleton detection when using realsense cameras

### DIFF
--- a/multi_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
+++ b/multi_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
@@ -29,7 +29,7 @@
       <param name="caffe_proto" value="$(find rtpose_wrapper)/model/mpi/pose_deploy_linevec.prototxt"
       unless="$(arg use_coco)"/>
 
-    <param name="depth_topic"                   value="/$(arg sensor_name)/depth/image_rect_raw"/>
+    <param name="depth_topic"                value="/$(arg sensor_name)/aligned_depth_to_color/image_raw"/>
     <param name="rgb_topic"                  value="/$(arg sensor_name)/color/image_rect_color"/>
     <param name="camera_info_topic"          value="/$(arg sensor_name)/color/camera_info" />
 

--- a/single_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
+++ b/single_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
@@ -29,7 +29,7 @@
       <param name="caffe_proto" value="$(find rtpose_wrapper)/model/mpi/pose_deploy_linevec.prototxt"
       unless="$(arg use_coco)"/>
 
-    <param name="depth_topic"                   value="/$(arg sensor_name)/depth/image_rect_raw"/>
+    <param name="depth_topic"                value="/$(arg sensor_name)/aligned_depth_to_color/image_raw"/>
     <param name="rgb_topic"                  value="/$(arg sensor_name)/color/image_rect_color"/>
     <param name="camera_info_topic"          value="/$(arg sensor_name)/color/camera_info" />
 


### PR DESCRIPTION
The skeleton_detector node was subscribing to a depth image topic with a different resolution compared to the color image topic